### PR TITLE
update flask 2.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apispec==3.3.1
 apispec-webframeworks==0.5.2
-Flask==1.1.1
+Flask==2.3.2
 jsonmerge==1.7.0
 marshmallow==3.6.1
 PyYAML==5.4


### PR DESCRIPTION
## Why?

We are developing an application using Flask and flask-redoc, and we want to use Flask version 2.3.2 or higher version the vulnerability CVE-2023-30861.
However, we have been unable to update Flask because flask-redoc depends on old Flask functionality.
To resolve this, will update the Flask version that flask-redoc depends on and make necessary adjustments accordingly.

## Changes

* Updated Flask to version 2.3.2
* As `Flask.before_first_request` is no longer available, replaced it with `Flask.before_request`. Changed the process to only execute `docstrings_to_openapi` during the first request.